### PR TITLE
Doc ignore fix

### DIFF
--- a/TowerDefense/.gitignore
+++ b/TowerDefense/.gitignore
@@ -1,3 +1,5 @@
+# Modified for CS413 NAU Fall 2023
+
 # This .gitignore file should be placed at the root of your Unity project directory
 #
 # Get latest from https://github.com/github/gitignore/blob/main/Unity.gitignore


### PR DESCRIPTION
modified .gitignore back to a more standard format forcing it to look from current dir down, not bidirectional. Also edited the comments at the top. Closes #9 