### PR TITLE
Fixed Bug in Enemy Healthbar

### DIFF
--- a/TowerDefense/Assets/Scripts/Colony.cs
+++ b/TowerDefense/Assets/Scripts/Colony.cs
@@ -26,7 +26,6 @@ public class Colony : MonoBehaviour
 
     private void OnTriggerEnter( Collider collider )
     {
-        Debug.Log( collider.gameObject.name );
         Enemy enemy = collider.gameObject.GetComponent<Enemy>();
 
         if( enemy != null )

--- a/TowerDefense/Assets/Scripts/EnemyControls/Enemy.cs
+++ b/TowerDefense/Assets/Scripts/EnemyControls/Enemy.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
+using Unity.VisualScripting;
 using UnityEngine;
 
 
@@ -59,7 +60,7 @@ public class Enemy : MonoBehaviour
         set
         {
             _stats.health = value;
-            //healthBar.value = (float)health / (float)startHealth;
+            healthBar.value = (float)health / (float)startHealth;
             if(_stats.health <= 0)
             {
                 UIManagement.S.UpdateMoney(_stats.enemyCashValue);
@@ -87,11 +88,11 @@ public class Enemy : MonoBehaviour
     // Start is called before the first frame update
     void Start()
     {
-        //GameObject healthbarGO = Instantiate<GameObject>(healthBarPrefab,this.gameObject.transform);
-        //healthBar = healthbarGO.GetComponent<HealthBar>();
-        //Vector3 healthBarPos = healthbarGO.transform.position;
-        //healthBarPos.y = this.transform.localScale.y * 1f;
-        //healthbarGO.transform.position = healthBarPos;
+        GameObject healthbarGO = Instantiate<GameObject>(healthBarPrefab,this.gameObject.transform);
+        healthBar = healthbarGO.GetComponent<HealthBar>();
+        Vector3 healthBarPos = healthbarGO.transform.position;
+        healthBarPos.y = this.transform.position.y + this.transform.localScale.y * 1f;
+        healthbarGO.transform.position = healthBarPos;
     }
 
     // Update is called once per frame

--- a/TowerDefense/Assets/Scripts/_Scene_1_Waves.cs
+++ b/TowerDefense/Assets/Scripts/_Scene_1_Waves.cs
@@ -12,7 +12,6 @@ public class _Scene_1_Waves : MonoBehaviour
     public GameObject pathPrefab;
     public static float HEIGHT_BOUND = 6.5f;
     public static float WIDTH_BOUND = 14f;
-    private float waveDelay = 3f;
     private float spawnDelay = 1.0f;
     float speed = .1f;
     int numEnemies = 10;


### PR DESCRIPTION
Fixed bug in positioning of Enemy's healthbar. 
Previously, healthbar's y coordinate was using relative position instead of absolute position. 