### PR TITLE
Add Enemy5

### DIFF
--- a/TowerDefense/Assets/Materials/Enemy/Mat_TestEnemy5.mat
+++ b/TowerDefense/Assets/Materials/Enemy/Mat_TestEnemy5.mat
@@ -1,0 +1,32 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Mat_TestEnemy5
+  m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+  m_Parent: {fileID: 2100000, guid: 4657da41574b7e74982e022d7c194fff, type: 2}
+  m_ModifiedSerializedProperties: 2
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 6
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs: []
+    m_Ints: []
+    m_Floats:
+    - _Glossiness: 0
+    - _Metallic: 0
+    m_Colors:
+    - _Color: {r: 0.9339623, g: 0.9339623, b: 0.9339623, a: 1}
+  m_BuildTextureStacks: []

--- a/TowerDefense/Assets/Materials/Enemy/Mat_TestEnemy5.mat.meta
+++ b/TowerDefense/Assets/Materials/Enemy/Mat_TestEnemy5.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8f2d38fbaa5b70a4abb1564d97178c54
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TowerDefense/Assets/PreFab/Enemies/Enemy5.prefab
+++ b/TowerDefense/Assets/PreFab/Enemies/Enemy5.prefab
@@ -1,0 +1,150 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &2617143700200901817
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2558506595965045830}
+  - component: {fileID: 3221526993437879568}
+  - component: {fileID: 4628834876534609718}
+  - component: {fileID: 3365819522405792046}
+  - component: {fileID: -5439991989861383760}
+  - component: {fileID: 1082550756853930758}
+  m_Layer: 0
+  m_Name: Enemy5
+  m_TagString: Enemy
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2558506595965045830
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2617143700200901817}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 5, y: 5, z: 5}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &3221526993437879568
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2617143700200901817}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &4628834876534609718
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2617143700200901817}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 8f2d38fbaa5b70a4abb1564d97178c54, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!135 &3365819522405792046
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2617143700200901817}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!54 &-5439991989861383760
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2617143700200901817}
+  serializedVersion: 4
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_CenterOfMass: {x: 0, y: 0, z: 0}
+  m_InertiaTensor: {x: 1, y: 1, z: 1}
+  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ImplicitCom: 1
+  m_ImplicitTensor: 1
+  m_UseGravity: 0
+  m_IsKinematic: 1
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 1
+--- !u!114 &1082550756853930758
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2617143700200901817}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cbe08ceb0042de8489802f50c758d2a6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  healthBarPrefab: {fileID: 7206449404499547611, guid: 8ed479c1aacb5734f9b43de42f2e3d47, type: 3}
+  projectilePrefab: {fileID: 2443212768734570869, guid: dc3c729397670da48ae91efbe1d59267, type: 3}

--- a/TowerDefense/Assets/PreFab/Enemies/Enemy5.prefab.meta
+++ b/TowerDefense/Assets/PreFab/Enemies/Enemy5.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: eaddbcc3db363c94e848f6511b01308b
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TowerDefense/Assets/PreFab/Heroes/Hero 1.prefab
+++ b/TowerDefense/Assets/PreFab/Heroes/Hero 1.prefab
@@ -118,11 +118,10 @@ GameObject:
   - component: {fileID: 8555634714000408145}
   - component: {fileID: 4873040906081424484}
   - component: {fileID: 4962700337911840610}
-  - component: {fileID: -3134963506967301631}
   - component: {fileID: -2716338724416648410}
   m_Layer: 0
   m_Name: Hero 1
-  m_TagString: Untagged
+  m_TagString: Hero
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -213,7 +212,7 @@ CapsuleCollider:
     serializedVersion: 2
     m_Bits: 0
   m_LayerOverridePriority: 0
-  m_IsTrigger: 0
+  m_IsTrigger: 1
   m_ProvidesContacts: 0
   m_Enabled: 1
   serializedVersion: 2
@@ -248,27 +247,6 @@ Rigidbody:
   m_Interpolate: 0
   m_Constraints: 0
   m_CollisionDetection: 0
---- !u!135 &-3134963506967301631
-SphereCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1391541153952812289}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 1
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Radius: 5
-  m_Center: {x: 0, y: 0, z: 0}
 --- !u!114 &-2716338724416648410
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/TowerDefense/Assets/PreFab/Heroes/Hero 2.prefab
+++ b/TowerDefense/Assets/PreFab/Heroes/Hero 2.prefab
@@ -13,11 +13,10 @@ GameObject:
   - component: {fileID: 8555634714000408145}
   - component: {fileID: 4873040906081424484}
   - component: {fileID: 4962700337911840610}
-  - component: {fileID: -3134963506967301631}
   - component: {fileID: -5803013342744539490}
   m_Layer: 0
   m_Name: Hero 2
-  m_TagString: Untagged
+  m_TagString: Hero
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -139,27 +138,6 @@ Rigidbody:
   m_Interpolate: 0
   m_Constraints: 0
   m_CollisionDetection: 0
---- !u!135 &-3134963506967301631
-SphereCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1391541153952812289}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 1
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Radius: 5
-  m_Center: {x: 0, y: 0, z: 0}
 --- !u!114 &-5803013342744539490
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/TowerDefense/Assets/PreFab/Heroes/Hero 3.prefab
+++ b/TowerDefense/Assets/PreFab/Heroes/Hero 3.prefab
@@ -332,11 +332,10 @@ GameObject:
   - component: {fileID: 8555634714000408145}
   - component: {fileID: 4873040906081424484}
   - component: {fileID: 4962700337911840610}
-  - component: {fileID: -3134963506967301631}
   - component: {fileID: 6332701271868574096}
   m_Layer: 0
   m_Name: Hero 3
-  m_TagString: Untagged
+  m_TagString: Hero
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -458,27 +457,6 @@ Rigidbody:
   m_Interpolate: 0
   m_Constraints: 0
   m_CollisionDetection: 0
---- !u!135 &-3134963506967301631
-SphereCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1391541153952812289}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 1
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Radius: 5
-  m_Center: {x: 0, y: 0, z: 0}
 --- !u!114 &6332701271868574096
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/TowerDefense/Assets/PreFab/Projectile/EnemyProjectile.prefab
+++ b/TowerDefense/Assets/PreFab/Projectile/EnemyProjectile.prefab
@@ -1,0 +1,264 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &2443212768734570869
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7440697657648428089}
+  - component: {fileID: 8005034679999277899}
+  - component: {fileID: 2336223084463758161}
+  - component: {fileID: 8075564059809291876}
+  m_Layer: 0
+  m_Name: EnemyProjectile
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7440697657648428089
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2443212768734570869}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3654360270127798750}
+  - {fileID: 3905111239485115664}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &8005034679999277899
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2443212768734570869}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fff2ebc9eb701fa489ff2560f2fc4177, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!54 &2336223084463758161
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2443212768734570869}
+  serializedVersion: 4
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_CenterOfMass: {x: 0, y: 0, z: 0}
+  m_InertiaTensor: {x: 1, y: 1, z: 1}
+  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ImplicitCom: 1
+  m_ImplicitTensor: 1
+  m_UseGravity: 0
+  m_IsKinematic: 1
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
+--- !u!135 &8075564059809291876
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2443212768734570869}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!1 &4392713947369606181
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3654360270127798750}
+  - component: {fileID: 6543294233192002487}
+  - component: {fileID: 7772227515680326003}
+  m_Layer: 0
+  m_Name: ProjectileOutline
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3654360270127798750
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4392713947369606181}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.7071068, y: -0, z: -0, w: 0.7071068}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 0.0015, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 7440697657648428089}
+  m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
+--- !u!33 &6543294233192002487
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4392713947369606181}
+  m_Mesh: {fileID: 10206, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &7772227515680326003
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4392713947369606181}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 97bd57a84835b634aba89cc32c3aaddb, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!1 &9037723639943710723
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3905111239485115664}
+  - component: {fileID: 8293927618224427913}
+  - component: {fileID: 9111961500993355686}
+  m_Layer: 0
+  m_Name: ProjectileCenter
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3905111239485115664
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9037723639943710723}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.7071068, y: -0, z: -0, w: 0.7071068}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.95, y: 0.0019999999, z: 0.95}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 7440697657648428089}
+  m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
+--- !u!33 &8293927618224427913
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9037723639943710723}
+  m_Mesh: {fileID: 10206, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &9111961500993355686
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9037723639943710723}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 8a0b9b7872985804a96e6db82b262cc5, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}

--- a/TowerDefense/Assets/PreFab/Projectile/EnemyProjectile.prefab.meta
+++ b/TowerDefense/Assets/PreFab/Projectile/EnemyProjectile.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: dc3c729397670da48ae91efbe1d59267
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TowerDefense/Assets/PreFab/null.prefab
+++ b/TowerDefense/Assets/PreFab/null.prefab
@@ -1,0 +1,33 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &6265517451872536423
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3636242554270789577}
+  m_Layer: 0
+  m_Name: null
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3636242554270789577
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6265517451872536423}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -15.43776, y: -11.383, z: 5.990746}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/TowerDefense/Assets/PreFab/null.prefab.meta
+++ b/TowerDefense/Assets/PreFab/null.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 3683632c9f6e2fb4dad7c3749e9c4e3a
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TowerDefense/Assets/Scenes/_Scene_0.unity
+++ b/TowerDefense/Assets/Scenes/_Scene_0.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.44657898, g: 0.4964133, b: 0.5748178, a: 1}
+  m_IndirectSpecularColor: {r: 0.44657826, g: 0.49641263, b: 0.57481676, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -996,6 +996,7 @@ MonoBehaviour:
   enemyPrefab2: {fileID: 2617143700200901817, guid: 04ef0fb51aad75349bd073ef8c7f41bf, type: 3}
   enemyPrefab3: {fileID: 2617143700200901817, guid: 5a946b05cd477454db759e8ca2a04997, type: 3}
   enemyPrefab4: {fileID: 2617143700200901817, guid: 69911d2830ee4f6408dfafe662efbf0d, type: 3}
+  enemyPrefab42: {fileID: 2617143700200901817, guid: eaddbcc3db363c94e848f6511b01308b, type: 3}
   pathPrefab: {fileID: 9022901433475185932, guid: c1f1581588879d440abff4828dc44323, type: 3}
 --- !u!1 &404551946
 GameObject:

--- a/TowerDefense/Assets/Scenes/_Scene_1.unity
+++ b/TowerDefense/Assets/Scenes/_Scene_1.unity
@@ -617,6 +617,7 @@ MonoBehaviour:
   enemyPrefab2: {fileID: 2617143700200901817, guid: 04ef0fb51aad75349bd073ef8c7f41bf, type: 3}
   enemyPrefab3: {fileID: 2617143700200901817, guid: 5a946b05cd477454db759e8ca2a04997, type: 3}
   enemyPrefab4: {fileID: 2617143700200901817, guid: 69911d2830ee4f6408dfafe662efbf0d, type: 3}
+  enemyPrefab42: {fileID: 2617143700200901817, guid: eaddbcc3db363c94e848f6511b01308b, type: 3}
   pathPrefab: {fileID: 9022901433475185932, guid: c1f1581588879d440abff4828dc44323, type: 3}
 --- !u!114 &740921005 stripped
 MonoBehaviour:

--- a/TowerDefense/Assets/Scenes/_Scene_2.unity
+++ b/TowerDefense/Assets/Scenes/_Scene_2.unity
@@ -758,6 +758,7 @@ MonoBehaviour:
   enemyPrefab2: {fileID: 2617143700200901817, guid: 04ef0fb51aad75349bd073ef8c7f41bf, type: 3}
   enemyPrefab3: {fileID: 2617143700200901817, guid: 5a946b05cd477454db759e8ca2a04997, type: 3}
   enemyPrefab4: {fileID: 2617143700200901817, guid: 69911d2830ee4f6408dfafe662efbf0d, type: 3}
+  enemyPrefab42: {fileID: 2617143700200901817, guid: eaddbcc3db363c94e848f6511b01308b, type: 3}
   pathPrefab: {fileID: 9022901433475185932, guid: c1f1581588879d440abff4828dc44323, type: 3}
 --- !u!1001 &777325167
 PrefabInstance:

--- a/TowerDefense/Assets/Scenes/_Scene_3.unity
+++ b/TowerDefense/Assets/Scenes/_Scene_3.unity
@@ -603,6 +603,7 @@ MonoBehaviour:
   enemyPrefab2: {fileID: 2617143700200901817, guid: 04ef0fb51aad75349bd073ef8c7f41bf, type: 3}
   enemyPrefab3: {fileID: 2617143700200901817, guid: 5a946b05cd477454db759e8ca2a04997, type: 3}
   enemyPrefab4: {fileID: 2617143700200901817, guid: 69911d2830ee4f6408dfafe662efbf0d, type: 3}
+  enemyPrefab42: {fileID: 2617143700200901817, guid: eaddbcc3db363c94e848f6511b01308b, type: 3}
   pathPrefab: {fileID: 9022901433475185932, guid: c1f1581588879d440abff4828dc44323, type: 3}
 --- !u!1 &660124571
 GameObject:

--- a/TowerDefense/Assets/Scripts/Colony.cs
+++ b/TowerDefense/Assets/Scripts/Colony.cs
@@ -31,7 +31,6 @@ public class Colony : MonoBehaviour
         if( enemy != null )
         {
             colonyHealth -= enemy.damage;
-            Debug.Log( colonyHealth );
 
             //this may need to be changed if we decide to make a DESTROY_ENEMY() elsewhere.
             Destroy( enemy.gameObject );

--- a/TowerDefense/Assets/Scripts/DefaultStats.cs
+++ b/TowerDefense/Assets/Scripts/DefaultStats.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Collections.Generic;
+using Unity.VisualScripting;
 using UnityEngine;
 
 // note: prefabs are not assigned, adding get/set might work
@@ -9,26 +10,36 @@ public class DefaultStats : MonoBehaviour
     [HideInInspector]
     public static float enemySpeed1 = .1f;
     public static int enemyHealth1 = 2;
-    public static float enemyDamageToColony1 = .1f;
+    public static float enemyDamageToColony1 = .1001f;
     public static int enemyCashValue1 = 10;
 
     [HideInInspector]
     public static float enemySpeed2 = .15f;
     public static int enemyHealth2 = 6;
-    public static float enemyDamageToColony2 = .2f;
+    public static float enemyDamageToColony2 = .2001f;
     public static int enemyCashValue2 = 50;
 
     [HideInInspector]
     public static float enemySpeed3 = .12f;
     public static int enemyHealth3 = 10;
-    public static float enemyDamageToColony3 = .25f;
+    public static float enemyDamageToColony3 = .2501f;
     public static int enemyCashValue3 = 100;
 
     [HideInInspector]
     public static float enemySpeed4 = .07f;
     public static int enemyHealth4 = 35;
-    public static float enemyDamageToColony4 = .35f;
+    public static float enemyDamageToColony4 = .3501f;
     public static int enemyCashValue4 = 150;
+
+    [HideInInspector]
+    public static float enemySpeed5 = .035f;
+    public static int enemyHealth5 = 10;
+    public static float enemyDamageToColony5 = .05f;
+    public static int enemyCashValue5 = 0;
+    public static float EnemyAttackSpeed5 = .5f;
+    public static float IndestructibleDuration = 1f;
+    public static float EnemyProjectileSpeed5 = .5f;
+    public static float EnemyRangeRadius5 = 20f;
 
     ////////////////////////// hero //////////////////////////////////////////
     [HideInInspector]

--- a/TowerDefense/Assets/Scripts/EnemyControls/Enemy.cs
+++ b/TowerDefense/Assets/Scripts/EnemyControls/Enemy.cs
@@ -10,12 +10,12 @@ public class Enemy : MonoBehaviour
 {
     public PathIterator pathIter = null;
 
-    public GameObject healthBarPrefab; // prefab for healthBar
-    private HealthBar healthBar;
-    private int _health;
+    public GameObject healthBarPrefab; // prefab for private HealthBar healthBar;
+    private int _health = 0;
     public static int ENEMY_COUNT = 0;
+    private HealthBar healthBar = null;
 
-    public int health
+    public virtual int health
     {
         get
         {
@@ -53,9 +53,9 @@ public class Enemy : MonoBehaviour
     {
         get { return 0; }
     }
-    
+
     // Start is called before the first frame update
-    void Start()
+    protected void Start()
     {
         ENEMY_COUNT++;
         GameObject healthbarGO = Instantiate<GameObject>(healthBarPrefab,this.gameObject.transform);
@@ -63,7 +63,7 @@ public class Enemy : MonoBehaviour
         Vector3 healthBarPos = healthbarGO.transform.position;
         healthBarPos.y = this.transform.position.y + this.transform.localScale.y * 1f;
         healthbarGO.transform.position = healthBarPos;
-        Debug.Log("Initializing Health");
+
         // inialize health
         this.health = defaultHealth;
     }

--- a/TowerDefense/Assets/Scripts/EnemyControls/Enemy5.cs
+++ b/TowerDefense/Assets/Scripts/EnemyControls/Enemy5.cs
@@ -1,0 +1,68 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class Enemy5 : Enemy
+{
+    public GameObject projectilePrefab = null;
+    private bool indestructible;
+
+    public override float speed
+    {
+        get { return DefaultStats.enemySpeed5; }
+    }
+
+    public override int defaultHealth
+    {
+        get { return DefaultStats.enemyHealth5; }
+    }
+
+    public override float damage
+    {
+        get { return DefaultStats.enemyDamageToColony5; }
+    }
+
+    public override int enemyCashValue
+    {
+        get { return DefaultStats.enemyCashValue5; }
+    }
+
+    public override int health
+    {
+        get
+        {
+            return base.health;
+        }
+        set
+        {
+            bool takingDamage = value < base.health;
+            // only take damage if not taking damage or not indestructible
+            if( !takingDamage || !indestructible )
+            {
+                base.health = value;
+            }
+        }
+    }
+
+    protected new void Start()
+    {
+        // indestructible for 1 second to allow projectiles to affect heroes first
+        indestructible = true;
+        Invoke("SetIndestructibleFalse", DefaultStats.IndestructibleDuration );
+        InvokeRepeating("Attack", 0, DefaultStats.EnemyAttackSpeed5);
+        base.Start();
+    }
+
+    private void SetIndestructibleFalse()
+    {
+        indestructible = false;
+    }
+    
+    public void Attack()
+    {
+        EnemyProjectile projectile = Instantiate<GameObject>(projectilePrefab).GetComponent<EnemyProjectile>();
+        projectile.Init(this.transform.position, 
+                        DefaultStats.EnemyProjectileSpeed5, 
+                        DefaultStats.EnemyRangeRadius5);
+    }
+}

--- a/TowerDefense/Assets/Scripts/EnemyControls/Enemy5.cs.meta
+++ b/TowerDefense/Assets/Scripts/EnemyControls/Enemy5.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cbe08ceb0042de8489802f50c758d2a6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TowerDefense/Assets/Scripts/HeroScripts/Hero.cs
+++ b/TowerDefense/Assets/Scripts/HeroScripts/Hero.cs
@@ -2,15 +2,26 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
+// STANDARD: not affected by Enemy42
+// NOT_ATTACKING: does not attack
+// SLOWED_ATTACKING: heroAttackSpeed is increased
+// RANDOM_ATTACKING: Hero1/3 send projectiles in random direction
+// FRIENDLY_FIRE: Hero projectiles can destroy other heroes. 
+public enum HeroState { STANDARD, NOT_ATTACKING, RANDOM_ATTACKING, FRIENDLY_FIRE, SLOWED_ATTACKING }
+
 public class Hero : EnemyInRange
 {
-    private bool loaded = true; // starts loaded
+    private bool loaded; // starts loaded
     private bool reloading = false;
 
     // default damage/speed: override with children
     public virtual int HeroDamage
     {
         get { return 0; }
+    }
+    public virtual bool startsLoaded
+    {
+        get { return true; }
     }
     public virtual float HeroAttackSpeed
     {
@@ -24,6 +35,13 @@ public class Hero : EnemyInRange
     public virtual int projectionFrames
     {
         get { return 0; }
+    }
+
+    // for now, hero will destroy itself whenever health is updated
+    public int health
+    {
+        get { return -1; }
+        set { Destroy(this.gameObject); }
     }
 
     // Attack is the only function to be overwritten by children
@@ -42,6 +60,7 @@ public class Hero : EnemyInRange
     // Start is called before the first frame update
     void Start()
     {
+        loaded = startsLoaded;
         // start reloading when created
         Reload();
         eirCollider.Init(GetComponent<EnemyInRange>(), RangeRadius);
@@ -53,8 +72,11 @@ public class Hero : EnemyInRange
         // update EnemyInRange first
         base.Update();
 
+        // attempt to reload every frame
+        Reload();
+
         // attack if loaded and an enemy exists
-        if( loaded && EnemyList.Count > 0 )
+        if( loaded && EnemyList.Count > 0 && state != HeroState.NOT_ATTACKING )
         {
             Attack();
             // set to not loaded, then reload
@@ -69,22 +91,142 @@ public class Hero : EnemyInRange
         //   or already loaded
         if( !reloading && !loaded )
         {
+            // get the attack speed
+            float reloadTime = HeroAttackSpeed;
+            // increase reloadTime if SLOWED_ATTACKING
+            if( state == HeroState.SLOWED_ATTACKING )
+            {
+                reloadTime *= 5f;
+            }
+
             // start reloading process, finish reloading using attackspeed
             reloading = true;
-            Invoke("DoneReoading", HeroAttackSpeed);
+            Invoke("DoneReloading", reloadTime);
         }
     }
 
     // called after Reload completed, and only from Reload
-    private void DoneReoading()
+    private void DoneReloading()
     {
         // reloading done, set loaded
         loaded = true;
         reloading = false;
     }
 
-    public Vector3 projectEnemyPosition(Enemy enemy)
+    // calcuates direction a projectile needs to move to hit an enemy
+    public Vector3 projectAngleToEnemy( Enemy enemy )
     {
-        return (enemy.pathIter + projectionFrames).pos();
+        Vector3 heroPos = this.transform.position;
+        Vector3 enemyPos = (enemy.pathIter + projectionFrames).pos();
+        Vector3 enemyPositionVector = enemyPos - heroPos;
+        // apply angle innaccuracy
+        enemyPositionVector = Quaternion.Euler(0, 0, angleInaccuracy) * enemyPositionVector;
+        return enemyPositionVector;
+    }
+
+
+
+
+
+    ////////////////////////// contact with Projectile //////////////////////
+    // times to represent the first/last time the hero was contacted by EnemyProjectile
+    private float _timeFirstContact, _timeLastContact;
+    private bool hasBeenContacted = false;
+    public float timeSinceFirstContact
+    {
+        get
+        {
+            return Time.time - _timeFirstContact;
+        }
+    }
+
+    public float timeSinceLastContact
+    {
+        get
+        {
+            return Time.time - _timeLastContact;
+        }
+    }
+
+    // state based on time since first contact with Projectile42
+    public HeroState state
+    {
+        get
+        {
+            // not been contacted: standard state
+            if( !hasBeenContacted )
+            {
+                return HeroState.STANDARD;
+            }
+
+            // become not contacted after 2 seconds without contact
+            if( timeSinceLastContact > 2f )
+            {
+                hasBeenContacted = false;
+            }
+
+            // first phase: not attacking
+            if (timeSinceFirstContact < 5f)
+            {
+                return HeroState.NOT_ATTACKING;
+            }
+            // second phase: random attacking  - removed due to ability to defeat Enemy5 in this period
+            if ( timeSinceFirstContact < 5f )
+            {
+                return HeroState.RANDOM_ATTACKING;
+            }
+            // third phase: friendly fire (and random attacking)
+            if (timeSinceFirstContact < 15f)
+            {
+                return HeroState.FRIENDLY_FIRE;
+            }
+            // last phase (to end): slowed
+            return HeroState.SLOWED_ATTACKING;
+        }
+    }
+
+    // called when contacted by EnemyProjectile
+    public void OnContact()
+    {
+        if( !hasBeenContacted )
+        {
+            OnFirstContact();
+        }
+        _timeLastContact = Time.time;
+        hasBeenContacted = true;
+    }
+
+    // called when contacted by EnemyProjectile and not already contacted
+    public void OnFirstContact()
+    {
+        _timeFirstContact = Time.time;
+        loaded = false;
+    }
+
+    private void OnTriggerEnter(Collider other)
+    {
+        if (other.GetComponent<EnemyProjectile>() != null)
+        {
+            OnContact();
+        }
+    }
+
+    public bool friendlyFire
+    {
+        get { return state == HeroState.FRIENDLY_FIRE; }
+    }
+
+    public float angleInaccuracy
+    {
+        get
+        {
+            // if attacking randomly, return angle from 0-360
+            if (state == HeroState.RANDOM_ATTACKING ||
+                 state == HeroState.FRIENDLY_FIRE)
+            {
+                return Random.value * 360;
+            }
+            return 0;
+        }
     }
 }

--- a/TowerDefense/Assets/Scripts/HeroScripts/Hero1.cs
+++ b/TowerDefense/Assets/Scripts/HeroScripts/Hero1.cs
@@ -41,8 +41,8 @@ public class Hero1 : Hero
 
             // initialize the projectile in the direction of the nearest enemy
             projectile.Init(this.transform.position,
-                            projectEnemyPosition( enemyClosestToColony ) - this.transform.position,
-                            projectileSpeed, HeroDamage, true, RangeRadius);
+                            projectAngleToEnemy(enemyClosestToColony), 
+                            projectileSpeed, HeroDamage, true, RangeRadius, friendlyFire, this);
         }
     }
 }

--- a/TowerDefense/Assets/Scripts/HeroScripts/Hero2.cs
+++ b/TowerDefense/Assets/Scripts/HeroScripts/Hero2.cs
@@ -40,6 +40,6 @@ public class Hero2 : Hero
 
         // initialize the projectile in the direction of the nearest enemy
         projectile.Init(this.transform.position,
-                        projectileSpeed, HeroDamage, RangeRadius);
+                        projectileSpeed, HeroDamage, RangeRadius,friendlyFire, this);
     }
 }

--- a/TowerDefense/Assets/Scripts/HeroScripts/Hero3.cs
+++ b/TowerDefense/Assets/Scripts/HeroScripts/Hero3.cs
@@ -42,8 +42,8 @@ public class Hero3 : Hero
 
             // initialize the projectile in the direction of the nearest enemy
             projectile.Init(this.transform.position,
-                            projectEnemyPosition( enemyClosestToColony ) - this.transform.position,
-                            projectileSpeed, HeroDamage, false, RangeRadius);
+                            projectAngleToEnemy(enemyClosestToColony),
+                            projectileSpeed, HeroDamage, false, RangeRadius, friendlyFire, this);
         }
     }
 

--- a/TowerDefense/Assets/Scripts/Projectile/CircularProjectile.cs
+++ b/TowerDefense/Assets/Scripts/Projectile/CircularProjectile.cs
@@ -9,16 +9,21 @@ public class CircularProjectile : EnemyInRange
     private float RangeRadius;
     private float speed;
     private Vector3 initialPosition;
+    private bool friendlyFire;
+    private Hero source;
 
 
     public void Init(Vector3 initialPos, float speed, 
-                      int damage, float RangeRadius)
+                      int damage, float RangeRadius, bool friendlyFire, 
+                      Hero source)
     {
         this.RangeRadius = RangeRadius;
         this.initialPosition = initialPos;
         this.transform.position = initialPos;
         this.damage = damage;
         this.speed = speed;
+        this.friendlyFire = friendlyFire;
+        this.source = source;
         eirCollider.Init(GetComponent<EnemyInRange>(), RangeRadius);
     }
 
@@ -28,6 +33,11 @@ public class CircularProjectile : EnemyInRange
         if (enemy != null)
         {
             damageEnemy(enemy);
+        }
+        Hero hero = other.GetComponentInParent<Hero>();
+        if( hero != null )
+        {
+            damageHero(hero);
         }
     }
 
@@ -49,5 +59,11 @@ public class CircularProjectile : EnemyInRange
     public void damageEnemy(Enemy enemy)
     {
         enemy.health -= damage;
+    }
+    public void damageHero(Hero hero)
+    {
+        if (ReferenceEquals(hero, source)) return;
+        if (!friendlyFire) return;
+        hero.health -= damage;
     }
 }

--- a/TowerDefense/Assets/Scripts/Projectile/EnemyProjectile.cs
+++ b/TowerDefense/Assets/Scripts/Projectile/EnemyProjectile.cs
@@ -1,0 +1,72 @@
+using System.Collections;
+using System.Collections.Generic;
+using Unity.VisualScripting;
+using UnityEngine;
+
+public class EnemyProjectile : MonoBehaviour
+{
+    private bool rebound;
+    private float RangeRadius;
+    private float speed;
+    private Vector3 initialPosition;
+
+    public void Init(Vector3 initialPos, float speed,
+                      float RangeRadius)
+    {
+        this.RangeRadius = RangeRadius;
+        this.initialPosition = initialPos;
+        this.transform.position = initialPos;
+        this.speed = speed;
+    }
+
+    private void FixedUpdate()
+    {
+        Vector3 scale = this.transform.localScale;
+        // destroy projectile after reached RangeRadius
+        if (scale.x > RangeRadius )
+        {
+            Destroy(this.gameObject);
+        }
+        else
+        {
+            // increase the size of this
+            scale.x += speed;
+            scale.y += speed;
+            // set z scale of smaller projectiles higher to make them visible 
+            scale.z = ( RangeRadius * 2f - scale.x ) * 1f;
+            this.transform.localScale = scale;
+
+            // set position behind physical path
+            Vector3 thisPos = this.transform.position;
+            thisPos.z = 12f;
+            this.transform.position = thisPos;
+
+            // set the collider.position.z=0 and collider.radius=this.scale.x
+            {
+                // set z position to 0
+                Vector3 colliderPos = this.GetComponent<SphereCollider>().center;
+                colliderPos.z = -this.transform.position.z / this.transform.localScale.z;
+                this.GetComponent<SphereCollider>().center = colliderPos;
+
+
+                // set radius to x-scale (assume x=y)
+                // SphereCollider's radius at .5 will encapsulate the object's largest radius
+                float radius;
+                // case largest radius is x
+                if (this.transform.localScale.z <= this.transform.localScale.x)
+                {
+                    // raidus=.5f will match x's scale
+                    radius = .5f;
+                }
+                // otherwise, z is largest radius
+                else
+                {
+                    // radius=.5f will match z's scale
+                    // rescale to x's scale
+                    radius = .5f * (this.transform.localScale.x / this.transform.localScale.z);
+                }
+                this.GetComponent<SphereCollider>().radius = radius;
+            }
+        }
+    }
+}

--- a/TowerDefense/Assets/Scripts/Projectile/EnemyProjectile.cs.meta
+++ b/TowerDefense/Assets/Scripts/Projectile/EnemyProjectile.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fff2ebc9eb701fa489ff2560f2fc4177
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TowerDefense/Assets/Scripts/Projectile/LinearProjectile.cs
+++ b/TowerDefense/Assets/Scripts/Projectile/LinearProjectile.cs
@@ -10,11 +10,14 @@ public class LinearProjectile : EnemyInRange
     private float speed;
     private Vector3 initialPosition;
     private bool isDestroyed = false;
+    private bool friendlyFire;
+    private Hero source;
 
 
     public void Init( Vector3 initialPos, Vector3 direction, 
                       float speed, int initialDamage, 
-                      bool reboundPar, float RangeRadius)
+                      bool reboundPar, float RangeRadius, bool friendlyFire, 
+                      Hero source )
     {
         this.RangeRadius = RangeRadius;
         this.initialPosition = initialPos;
@@ -22,6 +25,8 @@ public class LinearProjectile : EnemyInRange
         this.damage = initialDamage;
         this.rebound = reboundPar;
         this.speed = speed;
+        this.friendlyFire = friendlyFire;
+        this.source = source;
         Vector3 vel = direction.normalized;
         vel *= speed;
         this.GetComponent<Rigidbody>().velocity = vel;
@@ -35,6 +40,11 @@ public class LinearProjectile : EnemyInRange
         if( enemy != null )
         {
             damageEnemy( enemy );
+        }
+        Hero hero = other.GetComponentInParent<Hero>();
+        if (hero != null)
+        {
+            damageHero(hero);
         }
     }
 
@@ -50,7 +60,6 @@ public class LinearProjectile : EnemyInRange
     {
         if( isDestroyed )
         {
-            Debug.Log("DESTROYED------------------------------------------");
             return;
         }
         damage -= enemy.health;
@@ -67,7 +76,8 @@ public class LinearProjectile : EnemyInRange
 
                 Init(this.transform.position,
                       this.nearestEnemy.transform.position - this.transform.position,
-                      this.speed, this.damage, this.rebound, this.RangeRadius);
+                      this.speed, this.damage, this.rebound, this.RangeRadius, 
+                      this.friendlyFire, this.source);
             }
         }
         else
@@ -89,5 +99,12 @@ public class LinearProjectile : EnemyInRange
         rotation.z = angle - Mathf.PI / 2;
         rotation.z *= Mathf.Rad2Deg;
         this.transform.eulerAngles = rotation;
+    }
+
+    public void damageHero(Hero hero)
+    {
+        if (ReferenceEquals(hero, source)) return;
+        if (!friendlyFire) return;
+        hero.health -= damage;
     }
 }

--- a/TowerDefense/Assets/Scripts/SceneWaves/_Scene_Waves.cs
+++ b/TowerDefense/Assets/Scripts/SceneWaves/_Scene_Waves.cs
@@ -18,6 +18,7 @@ public class _Scene_Waves : MonoBehaviour
     public GameObject enemyPrefab2;
     public GameObject enemyPrefab3;
     public GameObject enemyPrefab4;
+    public GameObject enemyPrefab42;
     public GameObject pathPrefab;
     
 
@@ -30,12 +31,13 @@ public class _Scene_Waves : MonoBehaviour
 
     private List<Path> _paths = new List<Path>();
     private List<List<Wave>> _waves = new List<List<Wave>>();
+    private int startWave = 1;
 
 
     // Start is called before the first frame update
     void Start()
     {
-        UIManagement.S.waveCurrent = 0;
+        UIManagement.S.waveCurrent = startWave - 1;
         _paths = InitializePaths();
         _waves = new List<List<Wave>>();
         foreach (Path path in _paths)
@@ -47,6 +49,16 @@ public class _Scene_Waves : MonoBehaviour
 
     private void Update()
     {
+        // Error where OnWavesEnd() is not called at end
+        //     Results: unable to reproduce so far
+        /*
+        Debug.Log("----------------------");
+        Debug.Log(Enemy.ENEMY_COUNT); // expect 0
+        Debug.Log(UIManagement.S.waveCurrent); // expect 10
+        Debug.Log(UIManagement.S.waveTotal); // expect 10
+        Debug.Log(Wave.WAVE_COUNT); // expect 0
+        */
+
         if (Enemy.ENEMY_COUNT == 0 && UIManagement.S.waveCurrent >= UIManagement.S.waveTotal && Wave.WAVE_COUNT == 0)
         {
             UIManagement.S.OnWavesEnd();
@@ -65,7 +77,7 @@ public class _Scene_Waves : MonoBehaviour
     {
         List<Wave> waves = new List<Wave>();
         Wave wave;
-
+        
         // wave 1
         {
             wave = createWaveOnPath(path);
@@ -73,7 +85,7 @@ public class _Scene_Waves : MonoBehaviour
 
             waves.Add(wave);
         }
-
+        
         // wave 2
         {
             wave = createWaveOnPath(path);
@@ -161,8 +173,65 @@ public class _Scene_Waves : MonoBehaviour
             wave.addEnemiesToWave(createSpawnData(1, 20, .25f));
             wave.addEnemiesToWave(createSpawnData(3, 20, .25f));
             wave.addEnemiesToWave(createSpawnData(1, 20, .25f));
-            wave.addEnemiesToWave(createSpawnData(4, 80, .5f));
+            wave.addEnemiesToWave(createSpawnData(4, 40, .3f));
 
+            waves.Add(wave);
+        }
+        
+        // wave 11
+        {
+            wave = createWaveOnPath(path);
+            wave.addEnemiesToWave(createSpawnData(1, 5, 1f));
+            wave.addEnemiesToWave(createSpawnData(5, 1, 5f));
+            wave.addEnemiesToWave(createSpawnData(1, 15, 1f));
+
+            waves.Add(wave);
+        }
+        
+        // wave 12
+        {
+            wave = createWaveOnPath(path);
+            wave.addEnemiesToWave(createSpawnData(3, 5, .5f));
+            wave.addEnemiesToWave(createSpawnData(5, 1, 10f));
+            wave.addEnemiesToWave(createSpawnData(3, 6, 2.5f));
+
+            waves.Add(wave);
+        }
+
+        // wave 13
+        {
+            wave = createWaveOnPath(path);
+            wave.addEnemiesToWave(createSpawnData(4, 5, 1f));
+            wave.addEnemiesToWave(createSpawnData(5, 1, 10f));
+            wave.addEnemiesToWave(createSpawnData(4, 5, 1f));
+            wave.addEnemiesToWave(createSpawnData(4, 1, 10f));
+            wave.addEnemiesToWave(createSpawnData(5, 1, 10f));
+
+            waves.Add(wave);
+        }
+
+        // wave 14
+        {
+            wave = createWaveOnPath(path);
+            wave.addEnemiesToWave(createSpawnData(1, 100, .05f));
+            wave.addEnemiesToWave(createSpawnData(5, 1, 0f));
+            wave.addEnemiesToWave(createSpawnData(4, 5, 2f));
+            wave.addEnemiesToWave(createSpawnData(4, 1, 30f));
+            wave.addEnemiesToWave(createSpawnData(5, 1, 0f));
+            wave.addEnemiesToWave(createSpawnData(4, 5, 2f));
+
+            waves.Add(wave);
+        }
+
+        // wave 15
+        {
+            wave = createWaveOnPath(path);
+            wave.addEnemiesToWave(createSpawnData(2, 50, .1f));
+            wave.addEnemiesToWave(createSpawnData(4, 10, .5f));
+            wave.addEnemiesToWave(createSpawnData(5, 1, 5f));
+            wave.addEnemiesToWave(createSpawnData(4, 10, .5f));
+            wave.addEnemiesToWave(createSpawnData(5, 1, 10f));
+            wave.addEnemiesToWave(createSpawnData(4, 100, .05f));
             waves.Add(wave);
         }
 
@@ -203,6 +272,10 @@ public class _Scene_Waves : MonoBehaviour
         else if (enemyID == 3)
         {
             prefab = enemyPrefab3;
+        }
+        else if (enemyID == 5)
+        {
+            prefab = enemyPrefab42;
         }
         else
         {

--- a/TowerDefense/ProjectSettings/TagManager.asset
+++ b/TowerDefense/ProjectSettings/TagManager.asset
@@ -5,6 +5,7 @@ TagManager:
   serializedVersion: 2
   tags:
   - Enemy
+  - Hero
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
Created Enemy5, which creates EnemyProjectile. 

Added hero states, determined by when it was contacted by an EnemyProjectile. 
STANDARD: hero acts normally. Before contacted by EnemyProjectile. 
NOT_ATTACKING: hero stops attacking. 0-5 seconds after contacted by EnemyProjectile. 
RANDOM_ATTACKING: launches projectiles in a random direction. 
FRIENDLY_FIRE: includes RANDOM_ATTACKING, projectiles can destroy other heroes. 5-15 seconds after contacted by EnemyProjectile. 
SLOWED_ATTACKING: hero attacks five times slower. 15+ seconds after contacted by EnemyProjectile. 
When a hero has not been contacted by EnemyProjectile for two seconds, returns to STANDARD state. 